### PR TITLE
EFF-164: update README examples for npx

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,1 +1,2 @@
 - 2026-01-13: Added root README with setup steps, CLI usage, generated files, and check commands.
+- 2026-01-13: Updated README CLI examples to use `npx -y lalph@latest`.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ A small CLI that connects to Linear, pulls the next set of unstarted issues into
 
 ## CLI usage
 
-- Run the main loop: `node dist/cli.js`
-- Select a Linear project: `node dist/cli.js select-project`
-- Select a label filter: `node dist/cli.js select-label`
-- Select a CLI agent: `node dist/cli.js select-agent`
+- Run the main loop: `npx -y lalph@latest`
+- Select a Linear project: `npx -y lalph@latest select-project`
+- Select a label filter: `npx -y lalph@latest select-label`
+- Select a CLI agent: `npx -y lalph@latest select-agent`
 
 The first run opens a Linear OAuth flow and stores the token locally.
 


### PR DESCRIPTION
## Summary
- update README CLI usage examples to use `npx -y lalph@latest`
- log progress entry for the README update