### PR TITLE
TIM-8 add .lalph gitignore note

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,3 +3,4 @@
 - 2026-01-13: Updated README to reference `pnpm build` and `pnpm check` scripts.
 - 2026-01-13: Added prompt guidance to check existing PRs and reviews.
 - 2026-01-13: Added CLI concurrency flag to run iterations in parallel.
+- 2026-01-13: Documented adding `.lalph/` to `.gitignore` in README.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A small CLI that connects to Linear, pulls the next set of unstarted issues into
 
 - Install dependencies: `pnpm install`
 - Build the CLI: `pnpm build`
+- Add `.lalph/` to `.gitignore` to keep local state private
 
 ## CLI usage
 


### PR DESCRIPTION
## Summary
- document adding `.lalph/` to `.gitignore` in setup steps
- record the update in `PROGRESS.md`