### PR TITLE
TIM-7 Remove checks section from README

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,3 +3,4 @@
 - 2026-01-13: Updated README to reference `pnpm build` and `pnpm check` scripts.
 - 2026-01-13: Added prompt guidance to check existing PRs and reviews.
 - 2026-01-13: Added CLI concurrency flag to run iterations in parallel.
+- 2026-01-13: Removed checks section from README for TIM-7.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,3 @@ The first run opens a Linear OAuth flow and stores the token locally.
 - `.lalph/prd.json`: synced task list pulled from Linear; update task states here.
 - `PROGRESS.md`: append-only log of work completed by the agent.
 - `.lalph/config`: local key-value store for Linear tokens and user selections.
-
-## Checks
-
-- Type check + format: `pnpm check`


### PR DESCRIPTION
## Summary
- remove the README checks section to avoid outdated guidance
- note the update in PROGRESS.md