### PR TITLE
TIM-60: add dependency metadata on create

### DIFF
--- a/.changeset/tim-60-create-dependency-metadata.md
+++ b/.changeset/tim-60-create-dependency-metadata.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+sync GitHub issue dependencies on creation


### PR DESCRIPTION
## Summary
- add blockedBy dependency sync after GitHub issue creation
- include changeset for patch release

## Testing
- pnpm check