### PR TITLE
TIM-85: prompt target branch creation

### DIFF
--- a/src/PromptGen.ts
+++ b/src/PromptGen.ts
@@ -89,7 +89,7 @@ permission.
 
 1. Your job is to complete the task with id \`${options.taskId}\` from the prd.yml file.
 2. Check if there is an existing Github PR for the task, otherwise create a new
-   branch for the task.${options.targetBranch ? ` The target branch for the PR should be \`${options.targetBranch}\`.` : ""}
+   branch for the task.${options.targetBranch ? ` The target branch for the PR should be \`${options.targetBranch}\`. If the target branch does not exist, create it first.` : ""}
    - If there is an existing PR, checkout the branch for that PR.
    - If there is an existing PR, check if there are any new comments or requested
      changes, and address them as part of the task.


### PR DESCRIPTION
## Summary
- clarify instructions to create the target branch first when it does not exist
- keep the prompt guidance consistent with target-branch usage