### PR TITLE
TIM-90 Remove plan idea prompt

### DIFF
--- a/src/Planner.ts
+++ b/src/Planner.ts
@@ -16,7 +16,7 @@ export const plan = Effect.gen(function* () {
   yield* Effect.scoped(fs.open(lalphPlanPath, { flag: "a+" }))
 
   const cliCommand = cliAgent.commandPlan({
-    prompt: promptGen.planPrompt(),
+    prompt: promptGen.planPrompt,
     prdFilePath: pathService.join(worktree.directory, ".lalph", "prd.yml"),
   })
   const exitCode = yield* ChildProcess.make(

--- a/src/PromptGen.ts
+++ b/src/PromptGen.ts
@@ -123,7 +123,7 @@ task back to "todo" state with notes on why in the description.
 
 ${prdNotes}`
 
-      const planPrompt = () => `# Instructions
+      const planPrompt = `# Instructions
 
 1. Ask the user for the idea / request, then break it down into multiple smaller tasks
    that can be added to the prd.yml file.


### PR DESCRIPTION
## Summary
- make plan prompt a plain string to avoid extra prompt interaction
- pass the plan prompt directly into the plan agent command
- keep the plan flow creating/opening lalph-plan.md before running the agent