### PR TITLE
TIM-117: add reset option to run

### DIFF
--- a/.changeset/reset-source-run.md
+++ b/.changeset/reset-source-run.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+add reset option to the main run command

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,7 @@ const specsDirectory = Flag.directory("specs").pipe(
 )
 
 const reset = Flag.boolean("reset").pipe(
-  Flag.withDescription("Reset the current issue source before planning"),
+  Flag.withDescription("Reset the current issue source before running"),
   Flag.withAlias("r"),
 )
 
@@ -101,6 +101,7 @@ const root = Command.make("lalph", {
   targetBranch,
   maxIterationMinutes,
   stallMinutes,
+  reset,
 }).pipe(
   Command.withHandler(
     Effect.fnUntraced(function* ({
@@ -110,7 +111,11 @@ const root = Command.make("lalph", {
       targetBranch,
       maxIterationMinutes,
       stallMinutes,
+      reset,
     }) {
+      if (reset) {
+        yield* resetCurrentIssueSource
+      }
       yield* getOrSelectCliAgent
 
       const isFinite = Number.isFinite(iterations)


### PR DESCRIPTION
## Summary
- add reset flag to the main run command to clear issue source state
- update reset flag help text to apply to running
- add changeset for the new CLI option