### PR TITLE
TIM-118 Add PRD polling scheduler

### DIFF
--- a/.changeset/tim-118-prd-polling.md
+++ b/.changeset/tim-118-prd-polling.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Add a fixed-interval PRD polling loop that skips overlapping syncs.


### PR DESCRIPTION
## Summary
- add a guarded PRD sync runner to avoid overlapping polling work
- run a 30s polling loop alongside file watch syncs
- include changeset for the polling scheduler update

## Testing
- `pnpm check`