### PR TITLE
TIM-152 Improve GitHub CLI repo error

### DIFF
--- a/.changeset/github-cli-repo-not-found.md
+++ b/.changeset/github-cli-repo-not-found.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Improve the GitHub CLI repo discovery error message when a repository cannot be resolved.


### PR DESCRIPTION
## Summary
- replace CLI repo name Option handling with a dedicated tagged error when no repository is found
- add changeset documenting the improved GitHub CLI error message

Closes #126