### PR TITLE
TIM-153: Fix PR feedback empty-state for hidden threads

### DIFF
--- a/.changeset/pr-feedback-eligible-threads.md
+++ b/.changeset/pr-feedback-eligible-threads.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Fix PR feedback output when only hidden review threads exist.

--- a/src/Github/Cli.ts
+++ b/src/Github/Cli.ts
@@ -52,13 +52,13 @@ export class GithubCli extends ServiceMap.Service<GithubCli>()(
       const prFeedbackMd = (pr: number) =>
         reviewComments(pr).pipe(
           Effect.map(({ comments, reviewThreads }) => {
-            if (comments.length === 0 && reviewThreads.length === 0) {
-              return `No review comments found.`
-            }
-
             const eligibleReviewThreads = reviewThreads.filter(
               (thread) => thread.shouldDisplayThread,
             )
+
+            if (comments.length === 0 && eligibleReviewThreads.length === 0) {
+              return `No review comments found.`
+            }
 
             let content = `# PR feedback
 


### PR DESCRIPTION
## Summary
- treat hidden/filtered review threads as no feedback when no general comments exist
- keep PR feedback output consistent with eligible review thread filtering
- add changeset for patch release