### PR TITLE
TIM-155 Revert non-done issues to todo

### DIFF
--- a/.changeset/fresh-needles-prove.md
+++ b/.changeset/fresh-needles-prove.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Fix issue reversion so non-done updates return to todo.

--- a/src/Prd.ts
+++ b/src/Prd.ts
@@ -239,7 +239,7 @@ export class Prd extends ServiceMap.Service<
       maybeRevertIssue,
       revertUpdatedIssues: Effect.gen(function* () {
         for (const issue of updatedIssues.values()) {
-          if (issue.state !== "done") continue
+          if (issue.state === "done") continue
           yield* source.updateIssue({
             issueId: issue.id!,
             state: "todo",


### PR DESCRIPTION
## Summary
- revert updated non-done issues back to `todo` in `revertUpdatedIssues`
- add changeset for the behavior fix