### PR TITLE
TIM-159: mention default target branch in CLI help

### DIFF
--- a/.changeset/tim-159-target-branch-default.md
+++ b/.changeset/tim-159-target-branch-default.md
@@ -2,4 +2,4 @@
 "lalph": patch
 ---
 
-Mention the default PR base branch in the task prompt instructions.
+Mention the default PR base branch in the CLI help text.

--- a/src/PromptGen.ts
+++ b/src/PromptGen.ts
@@ -117,7 +117,7 @@ ${prdNotes()}`
    - Add important discoveries about the codebase, or challenges faced to the task's
      \`description\`. More details below.
 4. Run any checks / feedback loops, such as type checks, unit tests, or linting.
-5. ${!options.githubPrNumber ? `Create a pull request for this task.${options.targetBranch ? ` The target branch for the PR should be \`${options.targetBranch}\`. If the target branch does not exist, create it first.` : " The target branch defaults to the current branch."}` : "Update the pull request with your progress."}
+5. ${!options.githubPrNumber ? `Create a pull request for this task.${options.targetBranch ? ` The target branch for the PR should be \`${options.targetBranch}\`. If the target branch does not exist, create it first.` : ""}` : "Update the pull request with your progress."}
    ${sourceMeta.githubPrInstructions}
    The PR description should include a summary of the changes made.
    - **DO NOT** commit any of the files in the \`.lalph\` directory.

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -41,7 +41,7 @@ const concurrency = Flag.integer("concurrency").pipe(
 
 const targetBranch = Flag.string("target-branch").pipe(
   Flag.withDescription(
-    "Target branch for PRs. Env variable: LALPH_TARGET_BRANCH",
+    "Target branch for PRs. Defaults to current branch. Env variable: LALPH_TARGET_BRANCH",
   ),
   Flag.withAlias("b"),
   Flag.withFallbackConfig(Config.string("LALPH_TARGET_BRANCH")),


### PR DESCRIPTION
## Summary
- update the CLI help for --target-branch to mention it defaults to the current branch
- remove the default-branch note from the task prompt text
- adjust the changeset to match the CLI help update