### PR TITLE
TIM-160 Rename agent command to harness

### DIFF
--- a/.changeset/tim-160-harness-command.md
+++ b/.changeset/tim-160-harness-command.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Rename the CLI agent selector command to `harness`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { commandIssue } from "./commands/issue.ts"
 import { commandEdit } from "./commands/edit.ts"
 import { commandShell } from "./commands/shell.ts"
 import { commandSource } from "./commands/source.ts"
-import { commandAgent } from "./commands/agent.ts"
+import { commandHarness } from "./commands/agent.ts"
 import PackageJson from "../package.json" with { type: "json" }
 import { resetCurrentIssueSource } from "./IssueSources.ts"
 import { GithubCli } from "./Github/Cli.ts"
@@ -22,7 +22,7 @@ commandRoot.pipe(
     commandEdit,
     commandShell,
     commandSource,
-    commandAgent,
+    commandHarness,
   ]),
   // Common flags are handled here
   Command.provideEffectDiscard(

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -64,7 +64,7 @@ export const getOrSelectCliAgent = Effect.gen(function* () {
   return yield* selectCliAgent
 })
 
-export const commandAgent = Command.make("agent").pipe(
+export const commandHarness = Command.make("harness").pipe(
   Command.withDescription("Select the CLI agent to use"),
   Command.withHandler(() => selectCliAgent),
 )


### PR DESCRIPTION
## Summary
- rename the CLI agent selector subcommand to `harness`
- update CLI wiring to use the new command
- add a changeset entry

## Testing
- pnpm check