### PR TITLE
TIM-164: Configurable editor for issue creation

### DIFF
--- a/.changeset/configurable-issue-editor.md
+++ b/.changeset/configurable-issue-editor.md
@@ -3,4 +3,4 @@
 ---
 
 Allow configuring the editor used for issue creation (and prd editing) via
-`LALPH_EDITOR`, falling back to `EDITOR`.
+`LALPH_EDITOR`, falling back to `EDITOR`, defaulting to `nano`.

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -1,8 +1,9 @@
 import { Command } from "effect/unstable/cli"
 import { CurrentIssueSource } from "../IssueSources.ts"
-import { Config, Effect, Layer } from "effect"
+import { Effect, Layer } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { Prd } from "../Prd.ts"
+import { configEditor } from "../shared/config.ts"
 
 export const commandEdit = Command.make("edit").pipe(
   Command.withDescription("Open the prd.yml file in your editor"),
@@ -10,10 +11,7 @@ export const commandEdit = Command.make("edit").pipe(
     Effect.fnUntraced(
       function* () {
         const prd = yield* Prd
-        const editor = yield* Config.string("LALPH_EDITOR").pipe(
-          Config.orElse(() => Config.string("EDITOR")),
-          Config.withDefault(() => "nvim"),
-        )
+        const editor = yield* configEditor
 
         yield* ChildProcess.make(editor, [prd.path], {
           extendEnv: true,

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -1,10 +1,11 @@
 import { Command } from "effect/unstable/cli"
 import { CurrentIssueSource } from "../IssueSources.ts"
-import { Config, Effect, FileSystem, Schema } from "effect"
+import { Effect, FileSystem, Schema } from "effect"
 import { IssueSource } from "../IssueSource.ts"
 import { ChildProcess } from "effect/unstable/process"
 import { PrdIssue } from "../domain/PrdIssue.ts"
 import * as Yaml from "yaml"
+import { configEditor } from "../shared/config.ts"
 
 const issueTemplate = `---
 title: Issue Title
@@ -35,10 +36,7 @@ export const commandIssue = Command.make("issue").pipe(
       const tempFile = yield* fs.makeTempFileScoped({
         suffix: ".md",
       })
-      const editor = yield* Config.string("LALPH_EDITOR").pipe(
-        Config.orElse(() => Config.string("EDITOR")),
-        Config.withDefault(() => "nvim"),
-      )
+      const editor = yield* configEditor
       yield* fs.writeFileString(tempFile, issueTemplate)
 
       const exitCode = yield* ChildProcess.make(editor, [tempFile], {

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -1,0 +1,6 @@
+import { Config } from "effect"
+
+export const configEditor = Config.string("LALPH_EDITOR").pipe(
+  Config.orElse(() => Config.string("EDITOR")),
+  Config.withDefault(() => "nano"),
+)


### PR DESCRIPTION
## Summary
- centralize editor config in configEditor (LALPH_EDITOR -> EDITOR -> default nano)
- use helper for issue creation and prd editing
- update changeset for the nano default