### PR TITLE
TIM-165: enable Claude stream-json output

### DIFF
--- a/.changeset/tim-165-claude-stream-json.md
+++ b/.changeset/tim-165-claude-stream-json.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Enable stream-json output for Claude work runs to avoid false stall detection.

--- a/src/domain/CliAgent.ts
+++ b/src/domain/CliAgent.ts
@@ -48,7 +48,7 @@ const claude = new CliAgent({
       stdout: outputMode,
       stderr: outputMode,
       stdin: "inherit",
-    })`claude --dangerously-skip-permissions -p ${`@${prdFilePath}
+    })`claude --dangerously-skip-permissions --output-format stream-json -p ${`@${prdFilePath}
 
 ${prompt}`}`,
   commandPlan: ({ outputMode, prompt, prdFilePath }) =>


### PR DESCRIPTION
Summary:
- enable Claude work runs to emit stream-json output to prevent false stall detection