### PR TITLE
TIM-168: add dangerous plan flag

### DIFF
--- a/.changeset/dangerous-plan-mode.md
+++ b/.changeset/dangerous-plan-mode.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Add a --dangerous flag to plan mode to skip permission prompts for supported agents.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ npx -y lalph@latest
 - Run the main loop: `lalph`
 - Run multiple iterations with concurrency: `lalph --iterations 4 --concurrency 2`
 - Start plan mode: `lalph plan`
+- Start plan mode without permission prompts: `lalph plan --dangerous`
 - Choose your issue source: `lalph source`
 
 It is recommended to add `.lalph/` to your `.gitignore` to avoid committing your


### PR DESCRIPTION
## Summary
- add a --dangerous flag for plan mode and propagate to agent commandPlan implementations
- update README with plan mode usage
- add a changeset for the new flag