### PR TITLE
TIM-181: reduce blockedBy lookups

### DIFF
--- a/.changeset/linear-blockedby-todo.md
+++ b/.changeset/linear-blockedby-todo.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Skip blocked-by lookups for non-todo Linear issues.

--- a/src/Linear.ts
+++ b/src/Linear.ts
@@ -230,8 +230,11 @@ export const LinearIssueSource = Layer.effect(
             const linearState = linear.states.find(
               (s) => s.id === issue.stateId,
             )!
-            const blockedBy = yield* Stream.runCollect(linear.blockedBy(issue))
             const state = linearStateToPrdState(linearState)
+            const blockedBy =
+              state === "todo"
+                ? yield* Stream.runCollect(linear.blockedBy(issue))
+                : []
             return new PrdIssue({
               id: issue.identifier,
               title: issue.title,


### PR DESCRIPTION
## Summary
- skip Linear blocked-by lookups for non-todo issues to reduce API calls
- add changeset for patch release