### PR TITLE
TIM-182: reset in-progress issues on startup

### DIFF
--- a/.changeset/reset-in-progress.md
+++ b/.changeset/reset-in-progress.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Reset in-progress issues to todo before the root loop starts.

--- a/src/IssueSource.ts
+++ b/src/IssueSource.ts
@@ -42,6 +42,25 @@ export const checkForWork = Effect.gen(function* () {
   }
 })
 
+export const resetInProgress = Effect.gen(function* () {
+  const source = yield* IssueSource
+  const issues = yield* source.issues
+  const inProgress = issues.filter(
+    (issue): issue is PrdIssue & { id: string } =>
+      issue.state === "in-progress" && issue.id !== null,
+  )
+  if (inProgress.length === 0) return
+  yield* Effect.forEach(
+    inProgress,
+    (issue) =>
+      source.updateIssue({
+        issueId: issue.id,
+        state: "todo",
+      }),
+    { concurrency: 5, discard: true },
+  )
+})
+
 export class NoMoreWork extends Schema.ErrorClass<NoMoreWork>(
   "lalph/Prd/NoMoreWork",
 )({

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -24,7 +24,7 @@ import { ChildProcess } from "effect/unstable/process"
 import { Worktree } from "../Worktree.ts"
 import { getCommandPrefix, getOrSelectCliAgent } from "./agent.ts"
 import { Flag, CliError, Command } from "effect/unstable/cli"
-import { checkForWork } from "../IssueSource.ts"
+import { checkForWork, resetInProgress } from "../IssueSource.ts"
 import { CurrentIssueSource } from "../IssueSources.ts"
 import { GithubCli } from "../Github/Cli.ts"
 
@@ -127,6 +127,8 @@ export const commandRoot = Command.make("lalph", {
       yield* Effect.log(
         `Executing ${iterationsDisplay} iteration(s) with concurrency ${runConcurrency}`,
       )
+
+      yield* resetInProgress.pipe(Effect.provide(source))
 
       let iteration = 0
       let quit = false


### PR DESCRIPTION
## Summary
- add IssueSource helper to move in-progress issues back to todo
- run the reset before the root loop starts
- document the change in a changeset

#163