### PR TITLE
TIM-183: publish to GitHub npm registry

### DIFF
--- a/.changeset/blue-weeks-jump.md
+++ b/.changeset/blue-weeks-jump.md
@@ -1,5 +1,0 @@
----
-"lalph": patch
----
-
-Publish releases to the GitHub npm registry from CI.


### PR DESCRIPTION
## Summary
- publish release artifacts to GitHub Packages after changesets publish
- grant workflow packages: write permission for GitHub npm registry
- add changeset for the CI publishing update