### PR TITLE
TIM-566: Always revert tasks to todo on failure

### DIFF
--- a/.changeset/tim-566-revert-todo.md
+++ b/.changeset/tim-566-revert-todo.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Ensure failed runs always reset the task to todo.

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -86,12 +86,14 @@ const run = Effect.fnUntraced(
     yield* Effect.addFinalizer(
       Effect.fnUntraced(function* (exit) {
         if (exit._tag === "Success") return
-        const prd = yield* Prd
         if (taskId) {
-          yield* prd.maybeRevertIssue({
+          yield* source.updateIssue({
+            projectId,
             issueId: taskId,
+            state: "todo",
           })
         } else {
+          const prd = yield* Prd
           yield* prd.revertUpdatedIssues
         }
       }, Effect.ignore()),


### PR DESCRIPTION
## Summary
- ensure failed runs reset the chosen task back to todo via IssueSource
- keep fallback behavior to revert updated issues when no task was selected
- add changeset for the fix