### PR TITLE
TIM-567 Fetch remote before checkout

### DIFF
--- a/.changeset/tim-567-fetch-before-checkout.md
+++ b/.changeset/tim-567-fetch-before-checkout.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Fetch the target branch remote before checkout in worktree setup.

--- a/src/Worktree.ts
+++ b/src/Worktree.ts
@@ -120,6 +120,7 @@ const setupWorktree = Effect.fnUntraced(function* (options: {
 
   if (shouldUseWorktree) {
     const parsed = parseBranch(targetBranch.value)
+    yield* options.exec`git fetch ${parsed.remote}`
     const code = yield* options.exec`git checkout ${parsed.branchWithRemote}`
     if (code !== 0) {
       yield* options.exec`git checkout -b ${parsed.branch}`


### PR DESCRIPTION
## Summary
- fetch the target branch remote before worktree checkout
- keep worktree setup behavior intact when the branch is missing
- add a changeset for the patch release