### PR TITLE
TIM-568 Remove project kvs directory on removal

### DIFF
--- a/.changeset/remove-project-kvs-directory.md
+++ b/.changeset/remove-project-kvs-directory.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Remove per-project kvs data when a project is deleted.

--- a/src/commands/projects/rm.ts
+++ b/src/commands/projects/rm.ts
@@ -1,4 +1,4 @@
-import { Effect, Option } from "effect"
+import { Effect, FileSystem, Option, Path } from "effect"
 import { Command } from "effect/unstable/cli"
 import { allProjects, getAllProjects, selectProject } from "../../Projects.ts"
 import { Settings } from "../../Settings.ts"
@@ -8,6 +8,8 @@ export const commandProjectsRm = Command.make("rm").pipe(
   Command.withDescription("Remove a project"),
   Command.withHandler(
     Effect.fnUntraced(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const pathService = yield* Path.Path
       const projects = yield* getAllProjects
       if (projects.length === 0) {
         return yield* Effect.log("There are no projects to remove.")
@@ -15,6 +17,14 @@ export const commandProjectsRm = Command.make("rm").pipe(
       const project = yield* selectProject
       const newProjects = projects.filter((p) => p.id !== project.id)
       yield* Settings.set(allProjects, Option.some(newProjects))
+      const kvsPath = pathService.join(
+        ".lalph",
+        "projects",
+        encodeURIComponent(project.id),
+      )
+      if (yield* fs.exists(kvsPath)) {
+        yield* fs.remove(kvsPath)
+      }
     }),
   ),
   Command.provide(Settings.layer),


### PR DESCRIPTION
## Summary
- remove per-project kvs storage when deleting a project
- add a changeset for the behavior change