### PR TITLE
TIM-569 add task references to commit flow instructions

### DIFF
--- a/.changeset/tim-569-commit-references.md
+++ b/.changeset/tim-569-commit-references.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+require commit flow instructions to add task references in commits

--- a/src/PromptGen.ts
+++ b/src/PromptGen.ts
@@ -172,6 +172,7 @@ ${options.task.description}
 5. ${options.gitFlow.commitInstructions({
         githubPrInstructions: sourceMeta.githubPrInstructions,
         githubPrNumber: options.githubPrNumber,
+        taskId: options.task.id ?? "unknown",
         targetBranch: options.targetBranch,
       })}
 6. **After ${options.gitFlow.requiresGithubPr ? "pushing" : "committing"}**


### PR DESCRIPTION
## Summary
- add task-id reference instruction to commit flow prompts
- pass task id into commit instruction builder
- add changeset for prompt update

## Testing
- `pnpm check`