### PR TITLE
TIM-607: Blank unchanged issue description

### DIFF
--- a/.changeset/empty-issue-description.md
+++ b/.changeset/empty-issue-description.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Blank out the default issue description placeholder when unchanged.

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -8,6 +8,8 @@ import { CurrentProjectId } from "../Settings.ts"
 import { layerProjectIdPrompt } from "../Projects.ts"
 import { Editor } from "../Editor.ts"
 
+const issueDescriptionPlaceholder = "Describe the issue here."
+
 const issueTemplate = `---
 title: Issue Title
 priority: 3
@@ -16,7 +18,7 @@ blockedBy: []
 autoMerge: false
 ---
 
-Describe the issue here.`
+${issueDescriptionPlaceholder}`
 
 const FrontMatterSchema = Schema.toCodecJson(
   Schema.Struct({
@@ -62,7 +64,12 @@ const handler = flow(
       const frontMatter = yield* Schema.decodeEffect(FrontMatterSchema)(
         Yaml.parse(yamlContent),
       )
-      const description = lines.slice(descriptionStartIndex).join("\n").trim()
+      const rawDescription = lines
+        .slice(descriptionStartIndex)
+        .join("\n")
+        .trim()
+      const description =
+        rawDescription === issueDescriptionPlaceholder ? "" : rawDescription
 
       yield* Effect.gen(function* () {
         const source = yield* IssueSource


### PR DESCRIPTION
## Summary
- treat the default issue description placeholder as empty when unchanged
- reuse a shared placeholder constant for the issue template and parser
- add a changeset for the behavior change

## Testing
- `pnpm check`