### PR TITLE
TIM-624: Move feedback line number from attribute to tag

### DIFF
--- a/.changeset/cold-chefs-listen.md
+++ b/.changeset/cold-chefs-listen.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Move PR review feedback line numbers from the `comment` attribute into a dedicated `<lineNumber>` XML tag.

--- a/src/Github/Cli.ts
+++ b/src/Github/Cli.ts
@@ -149,10 +149,9 @@ export class GithubCliRepoNotFound extends Data.TaggedError(
 const renderReviewComments = (
   comment: ReviewComment,
   followup: Array<ReviewComment>,
-) => `<comment author="${comment.author.login}" path="${comment.path}"${
-  comment.originalLine ? ` originalLine="${comment.originalLine}"` : ""
-}>
+) => `<comment author="${comment.author.login}" path="${comment.path}">
   <diffHunk>${comment.diffHunk}</diffHunk>
+  ${comment.originalLine ? `<lineNumber>${comment.originalLine}</lineNumber>` : ""}
   <body>${comment.body}</body>${
     followup.length > 0
       ? `


### PR DESCRIPTION
## Summary
- update PR feedback XML rendering to move line numbers out of the `<comment>` attributes and into a `<lineNumber>` tag
- keep the existing review comment structure (`diffHunk`, `body`, follow-ups) while changing line number placement
- add a changeset for the patch release

## Validation
- pnpm check