### PR TITLE
TIM-646: fix Claude chooser prompt argument parsing

### DIFF
--- a/.changeset/wicked-trainers-double.md
+++ b/.changeset/wicked-trainers-double.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Fix Claude chooser invocation by inserting `--` before the prompt argument when using `--disallowed-tools`. This prevents variadic tool parsing from swallowing the positional prompt and restores chooser task selection.

--- a/src/domain/CliAgent.ts
+++ b/src/domain/CliAgent.ts
@@ -84,6 +84,7 @@ const claude = new CliAgent({
         "--disallowed-tools",
         "AskUserQuestion",
         ...extraArgs,
+        "--",
         `@${prdFilePath}
 
 ${prompt}`,


### PR DESCRIPTION
## Summary
- add `--` before the Claude chooser prompt positional argument in `CliAgent.command`
- prevent variadic `--disallowed-tools` parsing from swallowing the prompt
- add a patch changeset for the CLI regression fix

## Validation
- `pnpm check`