### PR TITLE
TIM-645 Preserve existing GitHub labels during issue updates

### DIFF
--- a/.changeset/tim-645-github-label-preservation.md
+++ b/.changeset/tim-645-github-label-preservation.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Preserve existing GitHub issue labels during `updateIssue` and only apply explicit label changes for workflow state and auto-merge labels.


### PR DESCRIPTION
## Summary
- fetch the current GitHub issue labels in `GithubIssueSource.updateIssue` and use them as the base label set instead of rebuilding from only the configured label filter
- preserve existing labels when `autoMerge` is not provided, and apply explicit auto-merge toggles by adding/removing the configured auto-merge label
- normalize workflow labels on state updates by removing stale `in-progress` / `in-review` labels before applying the requested state label

## Validation
- `pnpm check`