### PR TITLE
TIM-652: Explicitly mark issues as done after auto merge

### DIFF
--- a/.changeset/tall-dots-switch.md
+++ b/.changeset/tall-dots-switch.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Mark tasks as done when PR auto-merge succeeds in PR git flow.

--- a/src/GitFlow.ts
+++ b/src/GitFlow.ts
@@ -81,6 +81,8 @@ After making any changes, commit and push them to the same pull request.
     postWork: () => Effect.void,
     autoMerge: Effect.fnUntraced(function* (options) {
       const prd = yield* Prd
+      const source = yield* IssueSource
+      const projectId = yield* CurrentProjectId
       const worktree = options.worktree
 
       let prState = (yield* worktree.viewPrState()).pipe(
@@ -101,6 +103,14 @@ After making any changes, commit and push them to the same pull request.
       prState = yield* worktree.viewPrState(prState.value.number)
       yield* Effect.log("PR state after merge", prState)
       if (Option.isSome(prState) && prState.value.state === "MERGED") {
+        const issue = yield* prd.findById(options.issueId)
+        if (issue && issue.state !== "done") {
+          yield* source.updateIssue({
+            projectId,
+            issueId: options.issueId,
+            state: "done",
+          })
+        }
         return
       }
       yield* Effect.log("Flagging unmergable PR")


### PR DESCRIPTION
## Summary
- Update PR git-flow auto-merge handling to explicitly mark the task issue as `done` when GitHub reports the PR merged.
- Keep existing unmergeable handling unchanged: if merge fails verification, task is flagged and PR is closed.
- Add a patch changeset for the auto-merge completion fix.

## Validation
- pnpm check