### PR TITLE
TIM-657: Prompt for preset selection in plan mode

### DIFF
--- a/.changeset/new-socks-agree.md
+++ b/.changeset/new-socks-agree.md
@@ -1,0 +1,7 @@
+---
+"lalph": patch
+---
+
+Prompt to choose an agent preset when running plan flows so `lalph plan` and
+`lalph plan tasks` can use any configured preset instead of always using the
+default.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ tasks from it.
 
 Use `--dangerous` to skip permission prompts during spec generation, and `--new`
 to create a project before starting plan mode.
+If you have multiple agent presets, plan commands prompt you to choose which
+preset to run before launching the CLI agent.
 
 ```bash
 lalph plan

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -11,7 +11,7 @@ import { agentPlanner } from "../Agents/planner.ts"
 import { agentTasker } from "../Agents/tasker.ts"
 import { commandPlanTasks } from "./plan/tasks.ts"
 import { Editor } from "../Editor.ts"
-import { getDefaultCliAgentPreset } from "../Presets.ts"
+import { selectCliAgentPreset } from "../Presets.ts"
 import { ChildProcess } from "effect/unstable/process"
 import { parseBranch } from "../shared/git.ts"
 
@@ -87,7 +87,7 @@ const plan = Effect.fnUntraced(
     const fs = yield* FileSystem.FileSystem
     const pathService = yield* Path.Path
     const worktree = yield* Worktree
-    const preset = yield* getDefaultCliAgentPreset
+    const preset = yield* selectCliAgentPreset
 
     yield* agentPlanner({
       plan: options.plan,

--- a/src/commands/plan/tasks.ts
+++ b/src/commands/plan/tasks.ts
@@ -7,7 +7,7 @@ import { PromptGen } from "../../PromptGen.ts"
 import { Settings } from "../../Settings.ts"
 import { Worktree } from "../../Worktree.ts"
 import { commandRoot } from "../root.ts"
-import { getDefaultCliAgentPreset } from "../../Presets.ts"
+import { selectCliAgentPreset } from "../../Presets.ts"
 import { CurrentIssueSource } from "../../CurrentIssueSource.ts"
 
 const specificationPath = Argument.path("spec", {
@@ -32,7 +32,7 @@ export const commandPlanTasks = Command.make("tasks", {
         const fs = yield* FileSystem.FileSystem
         const pathService = yield* Path.Path
         const worktree = yield* Worktree
-        const preset = yield* getDefaultCliAgentPreset
+        const preset = yield* selectCliAgentPreset
 
         const content = yield* fs.readFileString(specificationPath)
         const relative = pathService.relative(


### PR DESCRIPTION
## Summary
- prompt users to choose an agent preset for `lalph plan` before the planner/tasker agents are launched
- apply the same preset selection prompt to `lalph plan tasks` so all plan flows can run with a non-default preset
- add a changeset and README update describing preset selection behavior in plan commands

## Validation
- pnpm check