### PR TITLE
chore: use new effect-tsgo lsp

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lalph": "./dist/cli.mjs"
   },
   "scripts": {
-    "prepare": "husky && effect-language-service patch",
+    "prepare": "husky && effect-tsgo patch",
     "check": "concurrently \"pnpm tsgo --noEmit\" \"pnpm oxlint -c .oxlintrc.json\" \"pnpm build\"",
     "build": "tsdown",
     "prepublishOnly": "pnpm build"
@@ -48,6 +48,7 @@
     "@effect/ai-openai-compat": "4.0.0-beta.43",
     "@effect/language-service": "^0.84.2",
     "@effect/platform-node": "4.0.0-beta.43",
+    "@effect/tsgo": "0.1.0",
     "@linear/sdk": "^80.0.0",
     "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
     "@octokit/types": "^16.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@effect/platform-node':
         specifier: 4.0.0-beta.43
         version: 4.0.0-beta.43(effect@4.0.0-beta.43)(ioredis@5.10.0)
+      '@effect/tsgo':
+        specifier: 0.1.0
+        version: 0.1.0
       '@linear/sdk':
         specifier: ^80.0.0
         version: 80.0.0(graphql@16.13.1)
@@ -226,6 +229,45 @@ packages:
     resolution: {integrity: sha512-VAMlkL3q7K6XPlCZ0l0BLsxsogUHIupkrMMQGHKbLFjhR/7NFfiI6ugPhExHTdiKZU3tUByYb7/3EcHilkcZpw==}
     peerDependencies:
       effect: ^4.0.0-beta.43
+
+  '@effect/tsgo-darwin-arm64@0.1.0':
+    resolution: {integrity: sha512-JhOvbiv4HV0LXnUdvfq8a0sn/dscVPce5GXyt1CsB77PfiQre8EkW+k+M/ph3/OGLqmAmbMkQGNR5jqphViqCQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@effect/tsgo-darwin-x64@0.1.0':
+    resolution: {integrity: sha512-A+zbwta9IQpI0MnFTIo7rs0g9lrolTWbyGHwb0oTjlzF+daWWAIFvSegbHVVYdDSqnjszbs1/HV56RVmJwtjjw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@effect/tsgo-linux-arm64@0.1.0':
+    resolution: {integrity: sha512-cyZXhLERlwkr4n2tLh9MQdx8N0DD4bF0mT96HtLh6xl1mRxhuztmJ9WAhtu/aB6QP6jovX2cYI/5z829cKWR3A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@effect/tsgo-linux-arm@0.1.0':
+    resolution: {integrity: sha512-Ry+Fn4f7K+dY9lnAlAFYj0fmt6HDrXFNHGr43fyeJcNzxALg2MV9CgDaZf1cAXkdR1Vem1ECvCZLq+zoXjrNYw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@effect/tsgo-linux-x64@0.1.0':
+    resolution: {integrity: sha512-ijoa09JyBIZUHoyVBJ311ehWN2uGsvPhCNyb9I4m7K2yazMdTNb3ljNV/vOTwSZJO6pNgaSk9ao/+EbCTyGIlw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@effect/tsgo-win32-arm64@0.1.0':
+    resolution: {integrity: sha512-0N6k86xL0EdEzMeI1Xdi+WGnykt1HnYagZrl0zq5zRtEwgdEseN0z70CCgpJIlxra8UTsSP4XRfBNhYdw09W7Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@effect/tsgo-win32-x64@0.1.0':
+    resolution: {integrity: sha512-ohH6cxe/Ha81rTiJ4hEH+oKc1f/iD6wafyLvF38yKBfhwtJayxch+KBMibkajM/WI8PNKHD2HivQAxyKh2NEQg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@effect/tsgo@0.1.0':
+    resolution: {integrity: sha512-tOXIYkGB4dpWRnnEnOcK/dG3LG0/r5/n0VKVzMFCr0azU27Ayenm8Ogx7kT/TeE3WAWry3Qebr2h4qRUzOb0eg==}
+    hasBin: true
 
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
@@ -2318,6 +2360,37 @@ snapshots:
     dependencies:
       better-sqlite3: 12.8.0
       effect: 4.0.0-beta.43
+
+  '@effect/tsgo-darwin-arm64@0.1.0':
+    optional: true
+
+  '@effect/tsgo-darwin-x64@0.1.0':
+    optional: true
+
+  '@effect/tsgo-linux-arm64@0.1.0':
+    optional: true
+
+  '@effect/tsgo-linux-arm@0.1.0':
+    optional: true
+
+  '@effect/tsgo-linux-x64@0.1.0':
+    optional: true
+
+  '@effect/tsgo-win32-arm64@0.1.0':
+    optional: true
+
+  '@effect/tsgo-win32-x64@0.1.0':
+    optional: true
+
+  '@effect/tsgo@0.1.0':
+    optionalDependencies:
+      '@effect/tsgo-darwin-arm64': 0.1.0
+      '@effect/tsgo-darwin-x64': 0.1.0
+      '@effect/tsgo-linux-arm': 0.1.0
+      '@effect/tsgo-linux-arm64': 0.1.0
+      '@effect/tsgo-linux-x64': 0.1.0
+      '@effect/tsgo-win32-arm64': 0.1.0
+      '@effect/tsgo-win32-x64': 0.1.0
 
   '@emnapi/core@1.9.1':
     dependencies:

--- a/src/GitFlow.ts
+++ b/src/GitFlow.ts
@@ -9,7 +9,6 @@ import { parseBranch } from "./shared/git.ts"
 import { AtomRegistry } from "effect/unstable/reactivity"
 import { CurrentProjectId } from "./Settings.ts"
 
-// @effect-diagnostics-next-line leakingRequirements:off
 export class GitFlow extends ServiceMap.Service<
   GitFlow,
   {

--- a/src/Github/TokenManager.ts
+++ b/src/Github/TokenManager.ts
@@ -58,14 +58,6 @@ export class TokenManager extends ServiceMap.Service<TokenManager>()(
             ),
         })
 
-      const promptPat = Effect.gen(function* () {
-        return yield* Prompt.password({
-          message:
-            "GitHub PAT with repo, read:user, read:project scopes (leave empty for OAuth)",
-          validate: (value) => Effect.succeed(value.trim()),
-        })
-      }).pipe(Effect.provideServices(promptEnv))
-
       const getNoLock: Effect.Effect<
         AccessToken,
         HttpClientError.HttpClientError | QuitError | Schema.SchemaError
@@ -73,12 +65,17 @@ export class TokenManager extends ServiceMap.Service<TokenManager>()(
         if (Option.isSome(currentToken)) {
           return currentToken.value
         }
-        const token = Redacted.value(yield* promptPat)
+        const prompt = Prompt.password({
+          message:
+            "GitHub PAT with repo, read:user, read:project scopes (leave empty for OAuth)",
+          validate: (value) => Effect.succeed(value.trim()),
+        })
+        const token = Redacted.value(yield* prompt)
         const accessToken =
           token.length > 0 ? new AccessToken({ token }) : yield* deviceCode
         yield* set(Option.some(accessToken))
         return accessToken
-      })
+      }).pipe(Effect.provideServices(promptEnv))
       const get = Semaphore.makeUnsafe(1).withPermit(getNoLock)
 
       const deviceCode = Effect.gen(function* () {

--- a/src/Presets.ts
+++ b/src/Presets.ts
@@ -131,9 +131,9 @@ export const addOrUpdatePreset = Effect.fnUntraced(function* (options?: {
 
   if (cliAgent.id === "clanka") {
     yield* Effect.log("Verifying Clanka model configuration...")
-    // @effect-diagnostics-next-line multipleEffectProvide:off
     yield* LanguageModel.generateText({ prompt: "say hello" }).pipe(
       Effect.ignore,
+      // @effect-diagnostics-next-line multipleEffectProvide:off
       Effect.provide(layerClankaModel(preset.extraArgs.join(" ")), {
         local: true,
       }),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,5 +39,6 @@
       }
     ]
   },
-  "include": ["src"]
+  "include": ["src"],
+  "$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
 }


### PR DESCRIPTION
The project was switched to tsgo for pnpm check but its still using the old incompatible effect-language-service.

Switch to and configure the new https://github.com/Effect-TS/tsgo implementation 

Also fixes a couple of lsp warnings that now resurface. 