### PR TITLE
fix: make worktree setup executable and use absolute PRD paths

### DIFF
--- a/.changeset/fix-worktree-prd-paths.md
+++ b/.changeset/fix-worktree-prd-paths.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+Fix temporary worktree setup script permissions and pass absolute PRD paths to CLI agents.

--- a/.changeset/warm-ears-post.md
+++ b/.changeset/warm-ears-post.md
@@ -1,0 +1,5 @@
+---
+"lalph": patch
+---
+
+make sure sh setup is executable

--- a/.changeset/warm-ears-post.md
+++ b/.changeset/warm-ears-post.md
@@ -1,5 +1,0 @@
----
-"lalph": patch
----
-
-make sure sh setup is executable

--- a/src/Agents/chooser.ts
+++ b/src/Agents/chooser.ts
@@ -63,7 +63,7 @@ export const agentChooser = Effect.fnUntraced(function* (options: {
   yield* pipe(
     options.preset.cliAgent.command({
       prompt: promptGen.promptChoose({ gitFlow }),
-      prdFilePath: pathService.join(".lalph", "prd.yml"),
+      prdFilePath: pathService.join(worktree.directory, ".lalph", "prd.yml"),
       extraArgs: options.preset.extraArgs,
     }),
     ChildProcess.setCwd(worktree.directory),

--- a/src/Agents/planner.ts
+++ b/src/Agents/planner.ts
@@ -31,7 +31,7 @@ export const agentPlanner = Effect.fnUntraced(function* (options: {
       prompt: promptGen.planPrompt(options),
       prdFilePath: options.ralph
         ? undefined
-        : pathService.join(".lalph", "prd.yml"),
+        : pathService.join(worktree.directory, ".lalph", "prd.yml"),
       dangerous: options.dangerous,
     }),
     ChildProcess.setCwd(worktree.directory),

--- a/src/Agents/reviewer.ts
+++ b/src/Agents/reviewer.ts
@@ -61,7 +61,7 @@ export const agentReviewer = Effect.fnUntraced(function* (options: {
           gitFlow,
         }),
       ),
-      prdFilePath: pathService.join(".lalph", "prd.yml"),
+      prdFilePath: pathService.join(worktree.directory, ".lalph", "prd.yml"),
       extraArgs: options.preset.extraArgs,
     }),
     ChildProcess.setCwd(worktree.directory),

--- a/src/Agents/tasker.ts
+++ b/src/Agents/tasker.ts
@@ -35,7 +35,7 @@ export const agentTasker = Effect.fnUntraced(function* (options: {
         specsDirectory: options.specsDirectory,
         specificationPath: options.specificationPath,
       }),
-      prdFilePath: pathService.join(".lalph", "prd.yml"),
+      prdFilePath: pathService.join(worktree.directory, ".lalph", "prd.yml"),
       extraArgs: options.preset.extraArgs,
     }),
     ChildProcess.setCwd(worktree.directory),

--- a/src/Agents/timeout.ts
+++ b/src/Agents/timeout.ts
@@ -29,7 +29,7 @@ export const agentTimeout = Effect.fnUntraced(function* (options: {
         taskId: task.id!,
         specsDirectory: options.specsDirectory,
       }),
-      prdFilePath: pathService.join(".lalph", "prd.yml"),
+      prdFilePath: pathService.join(worktree.directory, ".lalph", "prd.yml"),
     }),
     ralph: ({ task, specFile }) => ({
       mode: "ralph" as const,

--- a/src/Agents/worker.ts
+++ b/src/Agents/worker.ts
@@ -21,7 +21,7 @@ export const agentWorker = Effect.fnUntraced(function* (options: {
   const worktree = yield* Worktree
 
   const prdFilePath = CurrentTask.$match(options.currentTask, {
-    task: () => pathService.join(".lalph", "prd.yml"),
+    task: () => pathService.join(worktree.directory, ".lalph", "prd.yml"),
     ralph: () => undefined,
   })
 

--- a/src/Worktree.ts
+++ b/src/Worktree.ts
@@ -163,6 +163,8 @@ const setupWorktree = Effect.fnUntraced(function* (options: {
     ? worktreeSetupPath
     : cwdSetupPath
 
+  yield* fs.chmod(setupPath, 0o755)
+
   yield* ChildProcess.make({
     cwd: options.directory,
     shell: process.env.SHELL ?? true,


### PR DESCRIPTION
**Summary of changes:**
- Chmod the selected `scripts/worktree-setup.sh` before executing it in temporary worktrees.
- Pass absolute `.lalph/prd.yml` paths to CLI agents so tools like OpenCode can resolve the file reliably.

when installing lalph on my raspberry pi (through npm) and then running lalph, it comes up with a permission error on the setup script as it isnt an executable:
`/bin/bash: line 1: /tmp/Qvuo6e/scripts/worktree-setup.sh: Permission denied`

For some reason this doesnt happen when i install on my other linux machine or build locally. I think somewhere on the way the executable bit wasn't retained when copied into temp on my Pi

I also got this error: `Error: File not found: .lalph/prd.yml`

This is fixed by making sure the agent receives the absolute path:

```
   -   prdFilePath: pathService.join(".lalph", "prd.yml"),
   +   prdFilePath: pathService.join(worktree.directory, ".lalph", "prd.yml"),
```


**Tested on Raspberry Pi with:**
```sh
TMPDIR="$HOME/.cache/lalph-tmp" lalph --iterations 1 
```
Confirmed the temporary setup script was executable and the run proceeded into agent task selection.

